### PR TITLE
Reset context before running BuildAssemblyStubs

### DIFF
--- a/csharp/PythonNetStubGenerator/PythonTypes.cs
+++ b/csharp/PythonNetStubGenerator/PythonTypes.cs
@@ -14,6 +14,14 @@ namespace PythonNetStubGenerator
         private static readonly HashSet<string> CurrentNamespaces = new HashSet<string>();
         private static readonly HashSet<Type> OverloadedNonGenericTypes = new HashSet<Type>();
 
+        public static void Reset()
+        {
+            ClearCurrent();
+
+            AllExportedTypes.Clear();
+            DirtyNamespaces.Clear();
+            OverloadedNonGenericTypes.Clear();
+        }
 
         public static void CacheOverloadedNonGenericTypes(IEnumerable<Type> stubTypes)
         {

--- a/csharp/PythonNetStubGenerator/StubBuilder.cs
+++ b/csharp/PythonNetStubGenerator/StubBuilder.cs
@@ -12,6 +12,9 @@ namespace PythonNetStubGenerator
         
         public static DirectoryInfo BuildAssemblyStubs(DirectoryInfo destPath, FileInfo[] targetAssemblyPaths, DirectoryInfo[] searchPaths = null)
         {
+            // reset all context
+            Reset();
+
             // prepare resolver
             AppDomain.CurrentDomain.AssemblyResolve -= AssemblyResolve;
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
@@ -64,6 +67,12 @@ namespace PythonNetStubGenerator
 
 
             return destPath;
+        }
+
+        private static void Reset()
+        {
+            SearchPaths.Clear();
+            PythonTypes.Reset();
         }
 
         internal static void WriteStub(DirectoryInfo rootDirectory, string nameSpace, IEnumerable<Type> stubTypes)


### PR DESCRIPTION
### Abstract

The original code is static and has a global state. The state is passed even when running BuildAssemblyStubs, and it prevents generating stub files next time.

### Digest of changes

- Added some code to reset all state.

### Notes

The fix in this PR is not ideal. It is just for minimising modification this time. Eventually, the code should have its state in its instance, not the class.